### PR TITLE
Fix trailing comma in getCSVHeader() and toCSV()

### DIFF
--- a/src/main/java/com/flybotix/hfr/codex/Codex.java
+++ b/src/main/java/com/flybotix/hfr/codex/Codex.java
@@ -113,6 +113,7 @@ public class Codex <V, E extends Enum<E> & CodexOf<V>>{
     for(E e : set) {
       sb.append(e.toString().replaceAll("_", " ")).append(',');
     }
+    sb.substring(0, sb.length() - 1);
     return sb.toString();
   }
   
@@ -133,9 +134,10 @@ public class Codex <V, E extends Enum<E> & CodexOf<V>>{
     sb.append(meta().key()).append(',');
     sb.append(meta().id()).append(',');
     sb.append(meta().timestamp()).append(',');
-    for(int i = 0; i < mData.length; i++) {
+    for(int i = 0; i < mData.length - 1; i++) {
       sb.append(pToString.convert(mData[i])).append(',');
     }
+    sb.append(pToString.convert(mData[mData.length - 1]));
     return sb.toString();
   }
   


### PR DESCRIPTION
Alters getCSVHeader() and toCSV() to eliminate the trailing comma in CSV header and CSV rows.
See [here](https://tools.ietf.org/html/rfc4180#section-2) for more details.